### PR TITLE
Allow customizing the base URL

### DIFF
--- a/chatstream/__init__.py
+++ b/chatstream/__init__.py
@@ -48,10 +48,6 @@ else:
     from typing import ParamSpec, TypeGuard
 
 
-client = AsyncOpenAI(
-    api_key=os.environ["OPENAI_API_KEY"],  # this is also the default, it can be omitted
-)
-
 DEFAULT_MODEL: OpenAiModel = "gpt-3.5-turbo"
 DEFAULT_SYSTEM_PROMPT = "You are a helpful assistant."
 DEFAULT_TEMPERATURE = 0.7
@@ -347,8 +343,11 @@ class chat_server:
                 print(f"TOKENS USED: {tokens_total}")
 
             extra_kwargs = {}
-            if self.url() is not None:
-                extra_kwargs["base_url"] = self.url()
+
+            client = AsyncOpenAI(
+                base_url=self.url(),
+                api_key=os.environ["OPENAI_API_KEY"],  # this is also the default, it can be omitted
+            )
 
             # Launch a Task that updates the chat string asynchronously. We run this in
             # a separate task so that the data can come in without need to await it in

--- a/chatstream/__init__.py
+++ b/chatstream/__init__.py
@@ -348,7 +348,7 @@ class chat_server:
 
             extra_kwargs = {}
             if self.url() is not None:
-                extra_kwargs["url"] = self.url()
+                extra_kwargs["base_url"] = self.url()
 
             # Launch a Task that updates the chat string asynchronously. We run this in
             # a separate task so that the data can come in without need to await it in

--- a/chatstream/__init__.py
+++ b/chatstream/__init__.py
@@ -343,10 +343,10 @@ class chat_server:
                 print(f"TOKENS USED: {tokens_total}")
 
             extra_kwargs = {}
+	    
 
             client = AsyncOpenAI(
                 base_url=self.url(),
-                api_key=os.environ["OPENAI_API_KEY"],  # this is also the default, it can be omitted
             )
 
             # Launch a Task that updates the chat string asynchronously. We run this in

--- a/chatstream/__init__.py
+++ b/chatstream/__init__.py
@@ -347,6 +347,7 @@ class chat_server:
 
             client = AsyncOpenAI(
                 base_url=self.url(),
+                api_key="test",
             )
 
             # Launch a Task that updates the chat string asynchronously. We run this in


### PR DESCRIPTION
This is not a complete implementation... basically, we should allow:

- No API key (in case auth is handled another way)
- Targeting a different URL

The environment variable default is _true_, but we also get an error if we do not provide a value (hence `"test"`).

Just wanted to submit for discussion!